### PR TITLE
Features to support OpenAPI spec in Big Peer

### DIFF
--- a/utoipa-gen/src/component.rs
+++ b/utoipa-gen/src/component.rs
@@ -310,6 +310,7 @@ pub mod serde {
         pub rename: Option<String>,
         pub default: Option<bool>,
         pub flatten: Option<bool>,
+        pub skip_serializing_if: Option<bool>,
     }
 
     impl SerdeValue {
@@ -321,6 +322,9 @@ pub mod serde {
                 while let Some((tt, next)) = rest.token_tree() {
                     match tt {
                         TokenTree::Ident(ident) if ident == "skip" => value.skip = Some(true),
+                        TokenTree::Ident(ident) if ident == "skip_serializing_if" => {
+                            value.skip_serializing_if = Some(true)
+                        }
                         TokenTree::Ident(ident) if ident == "flatten" => value.flatten = Some(true),
                         TokenTree::Ident(ident) if ident == "rename" => {
                             if let Some((literal, _)) = parse_next_lit_str(next) {

--- a/utoipa-gen/src/component.rs
+++ b/utoipa-gen/src/component.rs
@@ -309,6 +309,7 @@ pub mod serde {
         pub skip: Option<bool>,
         pub rename: Option<String>,
         pub default: Option<bool>,
+        pub flatten: Option<bool>,
     }
 
     impl SerdeValue {
@@ -320,6 +321,7 @@ pub mod serde {
                 while let Some((tt, next)) = rest.token_tree() {
                     match tt {
                         TokenTree::Ident(ident) if ident == "skip" => value.skip = Some(true),
+                        TokenTree::Ident(ident) if ident == "flatten" => value.flatten = Some(true),
                         TokenTree::Ident(ident) if ident == "rename" => {
                             if let Some((literal, _)) = parse_next_lit_str(next) {
                                 value.rename = Some(literal)

--- a/utoipa-gen/src/component/schema.rs
+++ b/utoipa-gen/src/component/schema.rs
@@ -271,7 +271,10 @@ impl ToTokens for NamedStructSchema<'_> {
                     .property(#name, #schema_property)
                 });
 
-                if !schema_property.is_option() && !is_default(&container_rules, &field_rule) {
+                if !schema_property.is_option()
+                    && !is_default(&container_rules, &field_rule)
+                    && !is_skip_serializing_if(&field_rule)
+                {
                     object_tokens.extend(quote! {
                         .required(#name)
                     })
@@ -346,6 +349,14 @@ fn is_default(container_rules: &Option<SerdeContainer>, field_rule: &Option<Serd
             .as_ref()
             .and_then(|rule| rule.default.as_ref())
             .unwrap_or(&false)
+}
+
+#[inline]
+fn is_skip_serializing_if(field_rule: &Option<SerdeValue>) -> bool {
+    field_rule
+        .as_ref()
+        .map(|rule| rule.skip_serializing_if.is_some())
+        .unwrap_or(false)
 }
 
 #[cfg_attr(feature = "debug", derive(Debug))]

--- a/utoipa-gen/src/component/schema.rs
+++ b/utoipa-gen/src/component/schema.rs
@@ -194,13 +194,25 @@ struct NamedStructSchema<'a> {
 impl ToTokens for NamedStructSchema<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let container_rules = serde::parse_container(self.attributes);
+        let mut object_tokens = quote! { utoipa::openapi::ObjectBuilder::new() };
 
-        tokens.extend(quote! { utoipa::openapi::ObjectBuilder::new() });
+        let flatten_fields: Vec<&Field> = self
+            .fields
+            .iter()
+            .filter(|field| {
+                let field_rule = serde::parse_value(&field.attrs);
+                is_flatten(&field_rule)
+            })
+            .collect();
 
         self.fields
             .iter()
             .filter_map(|field| {
                 let field_rule = serde::parse_value(&field.attrs);
+
+                if is_flatten(&field_rule) {
+                    return None;
+                };
 
                 if is_not_skipped(&field_rule) {
                     Some((field, field_rule))
@@ -255,16 +267,57 @@ impl ToTokens for NamedStructSchema<'_> {
                     xml_value,
                 );
 
-                tokens.extend(quote! {
+                object_tokens.extend(quote! {
                     .property(#name, #schema_property)
                 });
 
                 if !schema_property.is_option() && !is_default(&container_rules, &field_rule) {
-                    tokens.extend(quote! {
+                    object_tokens.extend(quote! {
                         .required(#name)
                     })
                 }
             });
+
+        if !flatten_fields.is_empty() {
+            tokens.extend(quote! {
+                utoipa::openapi::AllOfBuilder::new()
+            });
+
+            for field in flatten_fields {
+                // TODO: Clean up duplicate code
+                let type_tree = &mut TypeTree::from_type(&field.ty);
+                let deprecated = super::get_deprecated(&field.attrs);
+                let attrs =
+                    SchemaAttr::<NamedField>::from_attributes_validated(&field.attrs, type_tree);
+
+                let override_type_tree = attrs
+                    .as_ref()
+                    .and_then(|field| field.as_ref().value_type.as_ref().map(TypeTree::from_type));
+
+                let xml_value = attrs
+                    .as_ref()
+                    .and_then(|named_field| named_field.as_ref().xml.as_ref());
+                let comments = CommentAttributes::from_attributes(&field.attrs);
+
+                let schema_property = SchemaProperty::new(
+                    override_type_tree.as_ref().unwrap_or(type_tree),
+                    Some(&comments),
+                    attrs.as_ref(),
+                    deprecated.as_ref(),
+                    xml_value,
+                );
+
+                tokens.extend(quote! {
+                    .item(#schema_property)
+                });
+            }
+
+            tokens.extend(quote! {
+                .item(#object_tokens)
+            })
+        } else {
+            tokens.extend(object_tokens)
+        }
 
         if let Some(deprecated) = super::get_deprecated(self.attributes) {
             tokens.extend(quote! { .deprecated(Some(#deprecated)) });
@@ -1183,6 +1236,13 @@ fn is_not_skipped(rule: &Option<SerdeValue>) -> bool {
     rule.as_ref()
         .map(|value| value.skip.is_none())
         .unwrap_or(true)
+}
+
+#[inline]
+fn is_flatten(rule: &Option<SerdeValue>) -> bool {
+    rule.as_ref()
+        .map(|value| value.flatten.is_some())
+        .unwrap_or(false)
 }
 
 /// Resolves the appropriate [`RenameRule`] to apply to the specified `struct` `field` name given a

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -1366,11 +1366,18 @@ fn derive_complex_enum_serde_tag() {
 }
 
 #[test]
-fn derive_flatten() {
+fn derive_serde_flatten() {
     #[derive(Serialize)]
-    struct Payload {
+    struct Record {
         amount: i64,
         description: String,
+    }
+
+    #[derive(Serialize)]
+    struct Pagination {
+        page: i64,
+        next_page: i64,
+        per_page: i64,
     }
 
     let value: Value = api_doc! {
@@ -1378,18 +1385,21 @@ fn derive_flatten() {
         struct NamedFields {
             id: &'static str,
             #[serde(flatten)]
-            record: Payload
+            record: Record,
+            #[serde(flatten)]
+            pagination: Pagination
         }
     };
-
-    println!("{value:#?}");
 
     assert_json_eq!(
         value,
         json!({
             "allOf": [
                 {
-                    "$ref": "#/components/schemas/Payload"
+                    "$ref": "#/components/schemas/Record"
+                },
+                {
+                    "$ref": "#/components/schemas/Pagination"
                 },
                 {
                     "type": "object",

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -1871,6 +1871,10 @@ fn derive_struct_with_uuid_type() {
 #[test]
 fn derive_parse_serde_field_attributes() {
     struct S;
+    fn is_zero(i: &u64) -> bool {
+        *i == 0
+    }
+
     let post = api_doc! {
         #[derive(Serialize)]
         #[serde(rename_all = "camelCase")]
@@ -1879,6 +1883,8 @@ fn derive_parse_serde_field_attributes() {
             id: String,
             #[serde(skip)]
             _p: PhantomData<S>,
+            #[serde(skip_serializing_if = "is_zero")]
+            i: u64,
             long_field_num: i64,
         }
     };

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -1025,6 +1025,87 @@ fn derive_complex_enum() {
 }
 
 #[test]
+fn derive_complex_enum_with_mapping() {
+    #[derive(Serialize)]
+    struct CreateResult {
+        id: String,
+    }
+
+    #[derive(Serialize)]
+    struct DeleteResult {
+        deleted: u64,
+    }
+
+    let value: Value = api_doc! {
+        #[derive(Serialize)]
+        #[serde(tag = "method")]
+        enum MyResult {
+            #[schema(mapping = "create")]
+            Create(CreateResult),
+            #[schema(mapping = "delete")]
+            Delete(DeleteResult)
+        }
+    };
+
+    assert_json_eq!(
+        value,
+        json!({
+            "discriminator": {
+                "propertyName": "method",
+                "mapping": {
+                    "create": "#/components/schemas/CreateResult",
+                    "delete": "#/components/schemas/DeleteResult"
+                }
+            },
+            "oneOf": [
+                {
+                    "allOf": [
+                        {
+                            "$ref": "#/components/schemas/CreateResult",
+                        },
+                        {
+                            "properties": {
+                                "method": {
+                                    "enum": [
+                                        "Create",
+                                    ],
+                                    "type": "string",
+                                },
+                            },
+                            "required": [
+                                "method",
+                            ],
+                            "type": "object",
+                        },
+                    ],
+                },
+                 {
+                    "allOf":  [
+                         {
+                            "$ref": "#/components/schemas/DeleteResult",
+                        },
+                         {
+                            "properties": {
+                                "method": {
+                                    "enum": [
+                                        "Delete",
+                                    ],
+                                    "type": "string",
+                                },
+                            },
+                            "required": [
+                                "method",
+                            ],
+                            "type": "object",
+                        },
+                    ],
+                },
+            ]
+        })
+    );
+}
+
+#[test]
 fn derive_complex_enum_title() {
     #[derive(Serialize)]
     struct Foo(String);

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -1366,6 +1366,48 @@ fn derive_complex_enum_serde_tag() {
 }
 
 #[test]
+fn derive_flatten() {
+    #[derive(Serialize)]
+    struct Payload {
+        amount: i64,
+        description: String,
+    }
+
+    let value: Value = api_doc! {
+        #[derive(Serialize)]
+        struct NamedFields {
+            id: &'static str,
+            #[serde(flatten)]
+            record: Payload
+        }
+    };
+
+    println!("{value:#?}");
+
+    assert_json_eq!(
+        value,
+        json!({
+            "allOf": [
+                {
+                    "$ref": "#/components/schemas/Payload"
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": "string",
+                        },
+                    },
+                    "required": [
+                        "id",
+                    ],
+                },
+            ]
+        })
+    );
+}
+
+#[test]
 fn derive_complex_enum_serde_tag_title() {
     #[derive(Serialize)]
     struct Foo(String);

--- a/utoipa/src/openapi.rs
+++ b/utoipa/src/openapi.rs
@@ -11,8 +11,8 @@ pub use self::{
     response::{Response, ResponseBuilder, Responses, ResponsesBuilder},
     schema::{
         AllOf, AllOfBuilder, Array, ArrayBuilder, Components, ComponentsBuilder, Discriminator,
-        KnownFormat, Object, ObjectBuilder, OneOf, OneOfBuilder, Ref, Schema, SchemaFormat,
-        SchemaType, ToArray,
+        DiscriminatorBuilder, KnownFormat, Object, ObjectBuilder, OneOf, OneOfBuilder, Ref, Schema,
+        SchemaFormat, SchemaType, ToArray,
     },
     security::SecurityRequirement,
     server::{Server, ServerBuilder, ServerVariable, ServerVariableBuilder},

--- a/utoipa/src/openapi/schema.rs
+++ b/utoipa/src/openapi/schema.rs
@@ -253,6 +253,8 @@ pub struct Discriminator {
     /// Defines a discriminator property name which must be found within all composite
     /// objects.
     pub property_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mapping: Option<BTreeMap<String, String>>
 }
 
 impl Discriminator {
@@ -265,12 +267,44 @@ impl Discriminator {
     /// # use utoipa::openapi::schema::Discriminator;
     /// let discriminator = Discriminator::new("pet_type");
     /// ```
-    pub fn new<I: Into<String>>(property_name: I) -> Self {
+    pub fn new<I: Into<String>>(property_name: I, mapping: Option<BTreeMap<String, String>>) -> Self {
         Self {
             property_name: property_name.into(),
+            mapping 
         }
     }
 }
+
+#[derive(Default)]
+pub struct DiscriminatorBuilder {
+    pub property_name: String,
+    pub mapping: Option<BTreeMap<String, String>>
+}
+
+impl DiscriminatorBuilder {
+    new!(pub DiscriminatorBuilder);
+
+    pub fn property_name<I: Into<String>>(mut self, property_name: I) -> Self {
+        set_value!(self property_name property_name.into())
+    }
+
+    pub fn mapping<I: Into<String>>(mut self, key: I, value: I) -> Self {
+        if let Some(mapping) = self.mapping.as_mut() {
+            mapping.insert(key.into(), value.into());
+        } else {
+            let mut mapping = BTreeMap::new();
+            mapping.insert(key.into(), value.into());
+            self.mapping = Some(mapping);
+        }
+
+        self
+    }
+
+    build_fn!(pub Discriminator property_name, mapping);
+}
+
+from!(Discriminator DiscriminatorBuilder property_name, mapping);
+
 
 /// OneOf [Composite Object][oneof] component holds
 /// multiple components together where API endpoint could return any of them.
@@ -1451,5 +1485,12 @@ mod tests {
             serialized_components,
             serde_json::to_string(&deserialized_components).unwrap()
         )
+    }
+
+    #[test]
+    fn discriminator_create() {
+        let builder = DiscriminatorBuilder::new();
+        builder.property_name("method").mapping("key".into(), "value".into());
+
     }
 }

--- a/utoipa/src/openapi/schema.rs
+++ b/utoipa/src/openapi/schema.rs
@@ -1490,7 +1490,7 @@ mod tests {
     #[test]
     fn discriminator_create() {
         let builder = DiscriminatorBuilder::new();
-        builder.property_name("method").mapping("key".into(), "value".into());
+        builder.property_name("method").mapping::<&str>("key", "value");
 
     }
 }


### PR DESCRIPTION
# User description
This PR add the following features to allow correct OpenAPI specification generation in Big Peer:

- [x] Support custom mapping with `#[schema(mapping = "...")]` syntax for Discriminator object.
- [x] Support `#[serde(flatten)]`. Internally, it generate an `allOf` object in OpenAPI spec.
- [x] Support `#[serde(skip_serializing_with)]`. If it's specify, it would make the field optional instead of required.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
NamedStructSchema_to_tokens_("NamedStructSchema.to_tokens"):::modified
SerdeValue_("SerdeValue"):::modified
is_flatten_("is_flatten"):::added
is_skip_serializing_if_("is_skip_serializing_if"):::added
ComplexEnum_to_tokens_("ComplexEnum.to_tokens"):::modified
SchemaAttr_UnnamedFieldStruct_c_parse_("SchemaAttr<UnnamedFieldStruct<'c>>.parse"):::modified
DiscriminatorBuilder_("DiscriminatorBuilder"):::added
NamedStructSchema_to_tokens_ -- "Respects serde flatten and skip_serializing_if attributes when building schemas." --> SerdeValue_
NamedStructSchema_to_tokens_ -- "Separates flattened fields into AllOf items instead of properties." --> is_flatten_
NamedStructSchema_to_tokens_ -- "Prevents marking skip_serializing_if fields as required." --> is_skip_serializing_if_
ComplexEnum_to_tokens_ -- "Reads `mapping` literal for variants to emit discriminator mappings." --> SchemaAttr_UnnamedFieldStruct_c_parse_
ComplexEnum_to_tokens_ -- "Builds Discriminator with property and variant schema mapping entries." --> DiscriminatorBuilder_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Enhances OpenAPI specification generation by supporting <code>#[serde(flatten)]</code>, <code>#[serde(skip_serializing_if)]</code>, and custom discriminator mappings. These changes ensure that complex Rust structures and Serde attributes are accurately reflected in the generated <code>utoipa</code> documentation.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/getditto/utoipa/2?tool=ast&topic=Schema+Generation>Schema Generation</a>
        </td><td>Implements logic to handle <code>flatten</code> and <code>skip_serializing_if</code> attributes in <code>NamedStructSchema</code>, and adds support for custom discriminator mappings in enums.<details><summary>Modified files (4)</summary><ul><li>utoipa-gen/src/component.rs</li>
<li>utoipa-gen/src/component/schema.rs</li>
<li>utoipa-gen/src/component/schema/attr.rs</li>
<li>utoipa-gen/tests/schema_derive_test.rs</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>juha7kukkonen@gmail.com</td><td>Move-serde-module-to-a...</td><td>October 28, 2022</td></tr>
<tr><td>jacob@jhalsey.com</td><td>Allow-manually-setting...</td><td>October 15, 2022</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/getditto/utoipa/2?tool=ast&topic=OpenAPI+Models>OpenAPI Models</a>
        </td><td>Extends the <code>Discriminator</code> model and introduces <code>DiscriminatorBuilder</code> to support explicit property mappings in the OpenAPI spec.<details><summary>Modified files (2)</summary><ul><li>utoipa/src/openapi.rs</li>
<li>utoipa/src/openapi/schema.rs</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>jacob@jhalsey.com</td><td>Allow-manually-setting...</td><td>October 15, 2022</td></tr>
<tr><td>juha7kukkonen@gmail.com</td><td>Fix-trait-support-for-...</td><td>September 24, 2022</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/getditto/utoipa/2?tool=ast>(Baz)</a>.